### PR TITLE
TypeError: Cannot set property 'id' of undefined

### DIFF
--- a/oscar.js
+++ b/oscar.js
@@ -844,7 +844,10 @@ OscarConnection.prototype._resetState = function() {
 
 OscarConnection.prototype._addConnection = function(id, services, host, port, cb) {
   var self = this;
-  self._state.connections[id] = net.createConnection(port, host);
+  
+  self._state.connections[id] = new net.Socket();
+  self._state.connections[id].connect(port, host);
+  
   self._state.connections[id].id = id;
   self._state.connections[id].neededServices = services;
   self._state.connections[id].serverType = (id === 'login' ? 'login' : 'BOS');


### PR DESCRIPTION
```
node-oscar/oscar.js:849
  self._state.connections[id].id = id;
                                 ^
TypeError: Cannot set property 'id' of undefined
```

This seems to be happening because line 848

```
self._state.connections[id] = net.createConnection(port, host);
```

Is returning 'undefined' meaning for some reason its not making the connection to the login server. I changed it to use a net.Socket connection instead and it seems to work. This is all under Node v0.6.5.
