### PR TITLE
fix for missing 'self' variable in 'notifyTyping'

### DIFF
--- a/oscar.js
+++ b/oscar.js
@@ -213,6 +213,7 @@ OscarConnection.prototype.warn = function(who, isAnonymous, cb) {
 };
 
 OscarConnection.prototype.notifyTyping = function(who, which) {
+  var self = this;
   who = str2bytes(''+who);
   if (who.length > MAX_SN_LEN)
     throw new Error('Screen names cannot be longer than ' + MAX_SN_LEN + ' characters');


### PR DESCRIPTION
Hi,

I've tried to use 'notifyTyping' method and found that it uses 'self' variable inside but it is not declared and it leads to error. I've added declaration of it.

Thank you for the great client!
