### PR TITLE
Fix error, if joinChat callback is missing

### DIFF
--- a/oscar.js
+++ b/oscar.js
@@ -593,6 +593,8 @@ OscarConnection.prototype.getOfflineMsgs = function() {
 };
 
 OscarConnection.prototype.joinChat = function(name, cb) {
+  cb = cb || function(err){console.log(err)}
+  
   var self = this;
   if (!self._state.chatrooms[name]) {
     var exchange = 4;


### PR DESCRIPTION
Should the callback be empty or a console log of the err by default?
